### PR TITLE
feat: amazon.awsコレクションの配置パスを明示的に設定

### DIFF
--- a/.github/workflows/Ansible-deploy.yml
+++ b/.github/workflows/Ansible-deploy.yml
@@ -42,4 +42,6 @@ jobs:
 
       # 6. Ansible Playbook 実行
       - name: Run Ansible playbook via SSM
-        run: ansible-playbook -i inventory.ini ansible/playbook.yml
+        run: |
+          ANSIBLE_COLLECTIONS_PATHS=~/.ansible/collections:/home/runner/.local/lib/python3.12/site-packages/ansible_collections \
+          ansible-playbook -i inventory.ini ansible/playbook.yml


### PR DESCRIPTION
amazon.awsコレクションの配置をAnsibleが探せていないため配置パスを明示的に設定